### PR TITLE
fixes issue when adding single domain to new app function and enables creation of different policy modes for Function App Deployment

### DIFF
--- a/PS.MTA-STS/functions/Add-PSMTASTSCustomDomain.ps1
+++ b/PS.MTA-STS/functions/Add-PSMTASTSCustomDomain.ps1
@@ -138,7 +138,8 @@
         }
 
         # Add the current domains to the list of new domains
-        $newCustomDomains = $currentHostnames + $customDomainsToAdd
+        # forcing currentHostnames to be an array, it could be a string if only single name is present.
+        $newCustomDomains = @($currentHostnames) + $customDomainsToAdd
     }
     
     process {


### PR DESCRIPTION
fixes #11 
Get-PS.MTASTSCustomDomain, returns a string when the function app is new (only a single hostname), which if adding a single domain causes the script to concatenate the hostnames rather than create an array 