### PR TITLE
Update deployFunctionApp.md

### DIFF
--- a/docs/deployFunctionApp.md
+++ b/docs/deployFunctionApp.md
@@ -151,7 +151,7 @@ On the new page, enter the following information (as described at step 4 of [Enh
   - Resource group: Select the resource group you created in the previous step
   - Function App Name: MTA-STS-FunctionApp (or any other name you like and complies with the naming rules)
   - Runtime stack: PowerShell Core
-  - Version: 7.2
+  - Version: 7.4
   - Region: Select the same region as you selected for the resource group
   - Operating System: Windows
   - Hosting options and plans: Consumption (Serverless)


### PR DESCRIPTION
PowerShell Core version 7.4 change because of 7.2 deprecation: https://github.com/Azure/azure-functions-powershell-worker/wiki/Upgrading-your-Azure-Function-Apps-to-run-on-PowerShell-7.4 No other action needed!